### PR TITLE
Fix for max supply

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,11 @@ For developing this you need Node.JS and just npm install.
 ## Any ideas?
 
 Do you have any new ideas, wishes or bugs for Kaspa explorer? Contact @lAmeR^#7173 at Kaspa Discord.
+
 Do you have any new ideas, wishes or bugs for Karlsen explorer? Contact @Lemois#8277 at Karlsen Discord.
 
 ## DONATION ♥
 
 Please consider a donation for Kaspa explorer team: [kaspa:qqkqkzjvr7zwxxmjxjkmxxdwju9kjs6e9u82uh59z07vgaks6gg62v8707g73](https://explorer.kaspa.org/addresses/kaspa:qqkqkzjvr7zwxxmjxjkmxxdwju9kjs6e9u82uh59z07vgaks6gg62v8707g73)
-Please consider a donation for Kaspa explorer team - even in the Karlsen network (they own the adress): [karlsen:qqe3p64wpjf5y27kxppxrgks298ge6lhu6ws7ndx4tswzj7c84qkjlrspcuxw](https://explorer.karlsencoin.com/addresses/karlsen:qqe3p64wpjf5y27kxppxrgks298ge6lhu6ws7ndx4tswzj7c84qkjlrspcuxw)
+
+Please consider a donation for Karlsen explorer team: [karlsen:qqe3p64wpjf5y27kxppxrgks298ge6lhu6ws7ndx4tswzj7c84qkjlrspcuxw](https://explorer.karlsencoin.com/addresses/karlsen:qqe3p64wpjf5y27kxppxrgks298ge6lhu6ws7ndx4tswzj7c84qkjlrspcuxw)

--- a/src/components/CoinsupplyBox.js
+++ b/src/components/CoinsupplyBox.js
@@ -89,11 +89,11 @@ const CBox = () => {
                 </tr>
                 <tr>
                     <td className="cardBoxElement align-top">Max <span className="approx">(approx.)</span></td>
-                    <td className="pt-1">28,700,000,000 KLS</td>
+                    <td className="pt-1">4,961,000,000 KLS</td>
                 </tr>
                 <tr>
                     <td className="cardBoxElement align-top">Mined</td>
-                    <td className="pt-1">{(circCoins / 28700000000 * 100).toFixed(2)} %</td>
+                    <td className="pt-1">{(circCoins / 4961000000 * 100).toFixed(2)} %</td>
                 </tr>
                 <tr>
                     <td className="cardBoxElement align-top">Block reward</td>


### PR DESCRIPTION
This PR fixes the wrong max supply in the coin supply card. It was hard coded from Kaspa explorer and had to be replaced.