### PR TITLE
Allow API and KGI address to be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,42 @@ written in JS with React.JS library.
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
-## Development
+## Deployment
 
-For developing this you need Node.JS and just npm install.
+For deploying the block explorer make sure that nodejs build
+environment is set up by running `npm --version`. The build requires
+to configure the following mandatory environment variables:
+
+* `REACT_APP_API_ADDRESS` which is the public address of the
+  REST API endpoint.
+* `REACT_APP_KGI_ADDRESS` which is the public address of the
+  graph inspector to inspect a specific block.
+
+The API endpoint and Graph Inspector must operate on a web server
+secured with SSL.
+
+Optionally you can specify the explorer version to show in the
+footer:
+
+* `REACT_APP_VERCEL_GIT_COMMIT_SHA` which is the version of
+  the running explorer instance (default: xxxxxx).
+
+Build the block explorer:
+
+```
+git clone https://github.com/karlsen-network/karlsen-explorer
+cd karlsen-explorer
+export REACT_APP_VERCEL_GIT_COMMIT_SHA="$(git log -1 --date=short --format="%h" | tr -d '-')"
+export REACT_APP_API_ADDRESS=api.karlsennetwork.com
+export REACT_APP_KGI_ADDRESS=kgi.karlsennetwork.com
+npm install
+```
+
+Start the block explorer:
+
+```
+node server.js
+```
 
 ## Any ideas?
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # KARLSEN EXPLORER
 
-This is a fork of Kaspa explorer used for the Karlsen network project [https://explorer.karlsencoin.com](https://explorer.karlsencoin.com) written in JS with React.JS library.
+This is a fork of Kaspa explorer used for the Karlsen network project
+[https://explorer.karlsennetwork.com](https://explorer.karlsennetwork.com)
+written in JS with React.JS library.
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
@@ -10,12 +12,14 @@ For developing this you need Node.JS and just npm install.
 
 ## Any ideas?
 
-Do you have any new ideas, wishes or bugs for Kaspa explorer? Contact @lAmeR^#7173 at Kaspa Discord.
+Do you have any new ideas, wishes or bugs for Kaspa explorer?
+Contact @lAmeR^#7173 at Kaspa Discord.
 
-Do you have any new ideas, wishes or bugs for Karlsen explorer? Contact @Lemois#8277 at Karlsen Discord.
+Do you have any new ideas, wishes or bugs for Karlsen explorer?
+Contact @Lemois#8277 at Karlsen Discord.
 
 ## DONATION ♥
 
 Please consider a donation for Kaspa explorer team: [kaspa:qqkqkzjvr7zwxxmjxjkmxxdwju9kjs6e9u82uh59z07vgaks6gg62v8707g73](https://explorer.kaspa.org/addresses/kaspa:qqkqkzjvr7zwxxmjxjkmxxdwju9kjs6e9u82uh59z07vgaks6gg62v8707g73)
 
-Please consider a donation for Karlsen explorer team: [karlsen:qqe3p64wpjf5y27kxppxrgks298ge6lhu6ws7ndx4tswzj7c84qkjlrspcuxw](https://explorer.karlsencoin.com/addresses/karlsen:qqe3p64wpjf5y27kxppxrgks298ge6lhu6ws7ndx4tswzj7c84qkjlrspcuxw)
+Please consider a donation for Karlsen explorer team: [karlsen:qqe3p64wpjf5y27kxppxrgks298ge6lhu6ws7ndx4tswzj7c84qkjlrspcuxw](https://explorer.karlsennetwork.com/addresses/karlsen:qqe3p64wpjf5y27kxppxrgks298ge6lhu6ws7ndx4tswzj7c84qkjlrspcuxw)

--- a/src/App.js
+++ b/src/App.js
@@ -23,6 +23,7 @@ import TxPage from './components/TxPage';
 import Dashboard from './Dashboard';
 import { getBlock } from './karlsen-api-client';
 import { Analytics } from '@vercel/analytics/react';
+import { apiAddress } from "./addresses";
 // import 'moment/min/locales';
 
 // var locale = window.navigator.userLanguage || window.navigator.language || "en";
@@ -30,7 +31,6 @@ import { Analytics } from '@vercel/analytics/react';
 // moment.locale('en');
 
 const buildVersion = process.env.REACT_APP_VERCEL_GIT_COMMIT_SHA || "xxxxxx"
-
 
 document.addEventListener("DOMContentLoaded", function () {
   window.addEventListener('scroll', function () {
@@ -45,7 +45,7 @@ document.addEventListener("DOMContentLoaded", function () {
   });
 });
 
-const socket = io("wss://api.karlsencoin.com", {
+const socket = io(`wss://${apiAddress}`, {
   path: '/ws/socket.io'
 });
 
@@ -90,7 +90,7 @@ function App() {
   }
 
   const updatePrice = () => {
-    fetch(`https://api.karlsencoin.com/info/market-data`, {
+    fetch(`https://${apiAddress}/info/market-data`, {
       headers: { "Cache-Control": "no-cache" }
     })
       .then(response => response.json())
@@ -219,7 +219,7 @@ function App() {
                       <Link className="blockinfo-link ms-3" to="/addresses/karlsen:qqe3p64wpjf5y27kxppxrgks298ge6lhu6ws7ndx4tswzj7c84qkjlrspcuxw"><BiDonateHeart size="1.3rem" /></Link>
                     </OverlayTrigger>
                     <OverlayTrigger placement="right" overlay={<Tooltip id="github">REST-API server</Tooltip>}>
-                      <a className="blockinfo-link ms-3" href="https://api.karlsencoin.com/" target="_blank"><SiFastapi size="1.3rem" /></a>
+                      <a className="blockinfo-link ms-3" href={`https://${apiAddress}/`} target="_blank"><SiFastapi size="1.3rem" /></a>
                     </OverlayTrigger>
                   </span>
                   <span className="px-3 build">|</span>
@@ -241,7 +241,7 @@ function App() {
                       <Link className="blockinfo-link ms-2" to="/addresses/karlsen:qqe3p64wpjf5y27kxppxrgks298ge6lhu6ws7ndx4tswzj7c84qkjlrspcuxw"><BiDonateHeart size="1.1rem" /></Link>
                     </OverlayTrigger>
                     <OverlayTrigger placement="right" overlay={<Tooltip id="github">REST-API server</Tooltip>}>
-                      <a className="blockinfo-link ms-2" href="https://api.karlsencoin.com/" target="_blank"><SiFastapi size="1.1rem" /></a>
+                      <a className="blockinfo-link ms-2" href={`https://${apiAddress}/`} target="_blank"><SiFastapi size="1.1rem" /></a>
                     </OverlayTrigger>
                   </span>
                 </Col>

--- a/src/addresses.js
+++ b/src/addresses.js
@@ -1,0 +1,7 @@
+const apiAddress = process.env.REACT_APP_API_ADDRESS;
+const kgiAddress = process.env.REACT_APP_KGI_ADDRESS;
+
+export {
+    apiAddress,
+    kgiAddress
+};

--- a/src/components/BlockInfo.js
+++ b/src/components/BlockInfo.js
@@ -12,6 +12,7 @@ import { getBlock, getTransactions } from '../karlsen-api-client.js';
 import BlueScoreContext from "./BlueScoreContext.js";
 import CopyButton from "./CopyButton.js";
 import PriceContext from "./PriceContext.js";
+import { kgiAddress } from "../addresses";
 
 const BlockLamp = (props) => {
     return <OverlayTrigger overlay={<Tooltip>It is a {props.isBlue ? "blue" : "red"} block!</Tooltip>}>
@@ -136,7 +137,7 @@ const BlockInfo = () => {
                                         <CopyButton text={blockInfo.verboseData.hash} />
                                         <OverlayTrigger overlay={<Tooltip id="tooltip-kgi">Open in Karlsen Graph Inspector</Tooltip>}>
                                             <span>
-                                                <BiNetworkChart className="ms-2 copy-symbol" size="20" onClick={() => { window.open(`https://kgi.karlsencoin.com/?hash=${id}`, '_blank'); }} />
+                                                <BiNetworkChart className="ms-2 copy-symbol" size="20" onClick={() => { window.open(`https://${kgiAddress}/?hash=${id}`, '_blank'); }} />
                                             </span>
                                         </OverlayTrigger>
                                     </Col>
@@ -254,7 +255,7 @@ const BlockInfo = () => {
                                                                 </Col></>
                                                                 :
                                                                 <><Col xs={12} sm={8} md={9} lg={9} xl={8} xxl={7} className="text-truncate">
-                                                                    <a className="blockinfo-link" href={`https://katnip.karlsencoin.com/tx/${txInput.previousOutpoint.transactionId}`} target="_blank">
+                                                                    <a className="blockinfo-link" href={`/txs/${txInput.previousOutpoint.transactionId}`} target="_blank">
                                                                         TX #{txInput.previousOutpoint.index || 0} {txInput.previousOutpoint.transactionId}
                                                                     </a>
                                                                 </Col><Col className="me-auto" xs={12} sm={4} md={2}></Col>

--- a/src/components/CoinsupplyBox.js
+++ b/src/components/CoinsupplyBox.js
@@ -5,6 +5,7 @@ import { useContext, useEffect, useState } from "react";
 import { numberWithCommas } from "../helper";
 import { getCoinSupply, getHalving } from '../karlsen-api-client';
 import PriceContext from "./PriceContext";
+import { apiAddress } from "../addresses";
 
 
 const CBox = () => {
@@ -42,7 +43,7 @@ const CBox = () => {
     }, [])
 
     async function getBlockReward() {
-        await fetch('https://api.karlsencoin.com/info/blockreward')
+        await fetch(`https://${apiAddress}/info/blockreward`)
             .then((response) => response.json())
             .then(d => {
                 setBlockReward(d.blockreward.toFixed(2))

--- a/src/components/KarlsendInfoBox.js
+++ b/src/components/KarlsendInfoBox.js
@@ -2,6 +2,7 @@ import { faMemory } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useEffect, useState } from "react";
 import { FaMemory } from 'react-icons/fa';
+import { apiAddress } from "../addresses";
 
 
 
@@ -9,7 +10,7 @@ const KarlsendInfoBox = () => {
     const [data, setData] = useState({});
 
     async function updateData() {
-        await fetch('https://api.karlsencoin.com/info/karlsend')
+        await fetch(`https://${apiAddress}/info/karlsend`)
             .then((response) => response.json())
             .then(d => setData(d))
             .catch(err => console.log("Error", err))

--- a/src/components/blocksupdater.js
+++ b/src/components/blocksupdater.js
@@ -1,8 +1,10 @@
+import { apiAddress } from "../addresses";
+
 let queryBlock = null
 let blocksCache = []
 
 function updateQueryBlockFromBlockDag() {
-    fetch('https://api.karlsencoin.com/info/blockdag')
+    fetch(`https://${apiAddress}/info/blockdag`)
         .then((response) => response.json())
         .then(d => {
             queryBlock = d.virtualParentHashes[0]
@@ -23,7 +25,7 @@ export function getNewBlocks(func, trimTo) {
         updateQueryBlockFromBlockDag()
     }
     if (queryBlock) {
-        fetch(`https://api.karlsencoin.com/blocks?lowHash=${queryBlock}&includeBlocks=true`)
+        fetch(`https://${apiAddress}/blocks?lowHash=${queryBlock}&includeBlocks=true`)
             .then((response) => response.json())
             .then(d => {
                 const blocks = d.blocks.map((x) => {

--- a/src/karlsen-api-client.js
+++ b/src/karlsen-api-client.js
@@ -1,7 +1,7 @@
-const API_BASE = "https://api.karlsencoin.com/"
+import { apiAddress } from "./addresses";
 
 export async function getBlock(hash) {
-    const res = await fetch(`${API_BASE}blocks/${hash}`, { headers: { 'Access-Control-Allow-Origin': '*' } })
+    const res = await fetch(`https://${apiAddress}/blocks/${hash}`, { headers: { 'Access-Control-Allow-Origin': '*' } })
         .then((response) => response.json())
         .then(data => {
             return data
@@ -11,7 +11,7 @@ export async function getBlock(hash) {
 
 
 export async function getTransaction(hash) {
-    const res = await fetch(`${API_BASE}transactions/${hash}`, { headers: { 'Access-Control-Allow-Origin': '*' } })
+    const res = await fetch(`https://${apiAddress}/transactions/${hash}`, { headers: { 'Access-Control-Allow-Origin': '*' } })
         .then((response) => response.json())
         .then(data => {
             return data
@@ -20,7 +20,7 @@ export async function getTransaction(hash) {
 }
 
 export async function getBlockdagInfo() {
-    const res = await fetch(`${API_BASE}info/blockdag`, { headers: { 'Access-Control-Allow-Origin': '*' } })
+    const res = await fetch(`https://${apiAddress}/info/blockdag`, { headers: { 'Access-Control-Allow-Origin': '*' } })
         .then((response) => response.json())
         .then(data => {
             return data
@@ -29,7 +29,7 @@ export async function getBlockdagInfo() {
 }
 
 export async function getCoinSupply() {
-    const res = await fetch(`${API_BASE}info/coinsupply`, { headers: { 'Access-Control-Allow-Origin': '*' } })
+    const res = await fetch(`https://${apiAddress}/info/coinsupply`, { headers: { 'Access-Control-Allow-Origin': '*' } })
         .then((response) => response.json())
         .then(data => {
             return data
@@ -38,7 +38,7 @@ export async function getCoinSupply() {
 }
 
 export async function getAddressBalance(addr) {
-    const res = await fetch(`${API_BASE}addresses/${addr}/balance`, { headers: { 'Access-Control-Allow-Origin': '*' } })
+    const res = await fetch(`https://${apiAddress}/addresses/${addr}/balance`, { headers: { 'Access-Control-Allow-Origin': '*' } })
         .then((response) => response.json())
         .then(data => {
             return data.balance
@@ -48,7 +48,7 @@ export async function getAddressBalance(addr) {
 
 
 export async function getAddressTxCount(addr) {
-    const res = await fetch(`${API_BASE}addresses/${addr}/transactions-count`, { headers: { 'Access-Control-Allow-Origin': '*' } })
+    const res = await fetch(`https://${apiAddress}/addresses/${addr}/transactions-count`, { headers: { 'Access-Control-Allow-Origin': '*' } })
         .then((response) => response.json())
         .then(data => {
             return data.total
@@ -59,7 +59,7 @@ export async function getAddressTxCount(addr) {
 
 
 export async function getAddressUtxos(addr) {
-    const res = await fetch(`${API_BASE}addresses/${addr}/utxos`, { headers: { 'Access-Control-Allow-Origin': '*' } })
+    const res = await fetch(`https://${apiAddress}/addresses/${addr}/utxos`, { headers: { 'Access-Control-Allow-Origin': '*' } })
         .then((response) => response.json())
         .then(data => {
             return data
@@ -70,7 +70,7 @@ export async function getAddressUtxos(addr) {
 
 
 export async function getHalving() {
-    const res = await fetch(`${API_BASE}info/halving`, { headers: { 'Access-Control-Allow-Origin': '*' } })
+    const res = await fetch(`https://${apiAddress}/info/halving`, { headers: { 'Access-Control-Allow-Origin': '*' } })
         .then((response) => response.json())
         .then(data => {
             return data
@@ -79,7 +79,7 @@ export async function getHalving() {
 }
 
 export async function getTransactionsFromAddress(addr, limit = 20, offset = 0) {
-    const res = await fetch(`${API_BASE}addresses/${addr}/full-transactions?limit=${limit}&offset=${offset}`, {
+    const res = await fetch(`https://${apiAddress}/addresses/${addr}/full-transactions?limit=${limit}&offset=${offset}`, {
         headers: {
             'Access-Control-Allow-Origin': '*',
             'content-type': 'application/json'
@@ -96,7 +96,7 @@ export async function getTransactionsFromAddress(addr, limit = 20, offset = 0) {
 
 
 export async function getTransactions(tx_list, inputs, outputs) {
-    const res = await fetch(`${API_BASE}transactions/search`, {
+    const res = await fetch(`https://${apiAddress}/transactions/search`, {
         headers: {
             'Access-Control-Allow-Origin': '*',
             'content-type': 'application/json'


### PR DESCRIPTION
In the latest version of the Karlsen and Kaspa block explorer, the REST-API server and the Graph Inspector address have been preset in the source code. This setup complicates the use of the explorer on a testnet. To address this, we have added two new environment variables that allow for the specification of these addresses when building the React frontend.

* `REACT_APP_API_ADDRESS` which is the public address of the REST API endpoint.
* `REACT_APP_KGI_ADDRESS` which is the public address of the graph inspector to inspect a specific block.

The API endpoint and Graph Inspector must operate on a web server secured with SSL.